### PR TITLE
handle empty protocol data

### DIFF
--- a/static/vigor22_gps.js
+++ b/static/vigor22_gps.js
@@ -230,8 +230,11 @@ function setMissingArea(missingArea) {
 };
 
 function updateMissingArea() {
-    let missingArea = turf.area(turf.difference(boundariesMultiPolygon,
-        turf.combine(protocolLayer.toGeoJSON()).features[0]));
+    let protocolMultiPolygon = turf.combine(protocolLayer.toGeoJSON()).features[0];
+    let missingArea = boundariesArea;
+    if (typeof protocolMultiPolygon !== "undefined") {
+        missingArea = turf.area(turf.difference(boundariesMultiPolygon, protocolMultiPolygon));
+    }
     setFinishedArea(boundariesArea - missingArea);
     setMissingArea(missingArea);
 };


### PR DESCRIPTION
When the protocol is empty, the boundaries area is assumed as missing area.